### PR TITLE
README nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can find detailed instructions [here](https://help.github.com/articles/invit
 
 ![Settings](images/settings.png)
 
-![Manage access](images/manage-access.png)
+<img src="images/manage-access.png" alt="Manage access" width="250"/>
 
 ![Invite teams or people](images/invite.png)
 
@@ -245,9 +245,9 @@ To do so, implement the function called `uses_available_letters` in `game.py`. T
 - Has two parameters:
    - `word`, the first parameter, describes some input word, and is a string
    - `letter_bank`, the second parameter, describes an array of drawn letters in a hand. You can expect this to be an array of ten strings, with each string representing a letter
-- Returns either `true` or `false`
-- Returns `true` if every letter in the `input` word is available (in the right quantities) in the `letter_bank`
-- Returns `false` if not; if there is a letter in `input` that is not present in the `letter_bank` or has too much of compared to the `letter_bank`
+- Returns either `True` or `False`
+- Returns `True` if every letter in the `input` word is available (in the right quantities) in the `letter_bank`
+- Returns `False` if not; if there is a letter in `input` that is not present in the `letter_bank` or has too much of compared to the `letter_bank`
 
 ### Wave 3: score_word
 


### PR DESCRIPTION
### Previously

- The embedded image for "Manage access" takes up the entire width of the doc when it doesn't need to be
- Python booleans are not capitalized

### Now
- Inject that sweet, sweet HTML into the markdown so max width is 250px (an arbitrary number)
- Python booleans are capitalized